### PR TITLE
move cap-website as main eclipse-cap website for the project

### DIFF
--- a/otterdog/eclipse-dataspace-cap.jsonnet
+++ b/otterdog/eclipse-dataspace-cap.jsonnet
@@ -10,7 +10,8 @@ orgs.newOrg('eclipse-dataspace-cap') {
     },
   },
   _repositories+:: [
-    orgs.newRepo('cap-website') {
+    orgs.newRepo('eclipse-dataspace-cap.github.io') {
+      aliases: ['cap-website'],
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
As we don't have other sub website, moving the current one as the main one for the project.

move cap-website as main eclipse-cap website for the project