### PR TITLE
Add gh pages and move cap-website as main eclipse-cap website for the project

### DIFF
--- a/otterdog/eclipse-dataspace-cap.jsonnet
+++ b/otterdog/eclipse-dataspace-cap.jsonnet
@@ -10,15 +10,15 @@ orgs.newOrg('eclipse-dataspace-cap') {
     },
   },
   _repositories+:: [
-    orgs.newRepo('cap-website') {
+    orgs.newRepo('eclipse-dataspace-cap.github.io') {
+      aliases: ['cap-website'],
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: true,
       description: "Conformity Assessment Policy and Credential Profile website",
       web_commit_signoff_required: false,
-
       gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_branch: "main",
       gh_pages_source_path: "/",
       environments: [
         orgs.newEnvironment('github-pages') {

--- a/otterdog/eclipse-dataspace-cap.jsonnet
+++ b/otterdog/eclipse-dataspace-cap.jsonnet
@@ -13,9 +13,17 @@ orgs.newOrg('eclipse-dataspace-cap') {
     orgs.newRepo('cap-website') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      delete_branch_on_merge: false,
-      description: "CAP project website",
+      delete_branch_on_merge: true,
+      description: "Conformity Assessment Policy and Credential Profile website",
       web_commit_signoff_required: false,
+
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
+      environments: [
+        orgs.newEnvironment('github-pages') {
+        },
+      ],
     },
   ],
 }


### PR DESCRIPTION
As we don't have other sub website, moving the current one as the main one for the project.

move cap-website as main eclipse-cap website for the project
